### PR TITLE
Regex and slugify fixes

### DIFF
--- a/Stargazer.py
+++ b/Stargazer.py
@@ -52,7 +52,7 @@ class Stargazer:
     def get_lists(self):
         url = f"https://github.com/{self.username}?tab=stars"
         response = requests.get(url)
-        pattern = f'href="/stars/{self.username}/lists/(\S+)".*?<h3 class="f4 text-bold no-wrap mr-3">(.*?)</h3>'
+        pattern = fr'href="/stars/{self.username}/lists/(\S+)"[\s\S]*?<h3 class=".*?">(.*?)</h3>'
         match = re.findall(pattern, response.text, re.DOTALL)
         self.star_lists = [(url, name.strip()) for url, name in match]
         return self.star_lists
@@ -156,13 +156,13 @@ class Stargazer:
             unique_slug = slug if count == 0 else f"{slug}-{count}"
             anchors[slug] = count + 1
             toc_lines.append(f"- [{section}](#{unique_slug})")
-        toc_lines.append("")
+        toc_lines.append("\n")
         return "\n".join(toc_lines)
 
     def slugify(self, text):
         slug = text.strip().lower()
         slug = re.sub(r"[^\w\s-]", "", slug)
-        slug = re.sub(r"\s+", "-", slug)
+        slug = re.sub(r"\s", "-", slug)
         return slug or "section"
 
 


### PR DESCRIPTION
Hello! Thank you for making this tool! It's been really helpful since the GitHub API doesn't offer star list info.

I made this PR to fix the following issues:

**1)** The regex that gaze-stars is currently using to pull the star list names off the webpage within `get_lists()`, no longer matches the current webpage patterns. The webpage no longer has the "no-wrap" class, therefore, the current regex no longer captures the list names properly. I wrote a new regex that is more general and can work with any amount or kind of classnames. So if GitHub decides to change the webpage for star lists, the regex is more forgiving.

**2)** Need an 'r' in front of the regex string in `get_lists()` to prevent the syntax error: _SyntaxWarning: invalid escape sequence '\S'_

**3)** For the `build_toc()` function, at the then end there is a line `toc_lines.append("")` which I assume is to add a newline between the ToC and the first star list section. However, append() will not add a newline by default like print() does, so we need to add one explicitly to get that space between the sections.

**4)** The `slugify()` function works for most cases, unless there are multiple spaces between words in the star list name. We need to use \s without the '+' in the regex so that each individual space gets it's own '-' and not just one '-' for a group of spaces. For instance, if we have a star list called "Programming / DSA", currently, Stargazer will slugify it to "programming-dsa". Although, that will create an invalid link. We would want it to be slugified to "programming--dsa", which would create a correct link that will highlighted and clickable link in the ToC.